### PR TITLE
Moved define directive to the top of NGIO file

### DIFF
--- a/Runtime/Scripts/NewgroundsIO/NGIO.cs
+++ b/Runtime/Scripts/NewgroundsIO/NGIO.cs
@@ -1,3 +1,8 @@
+// External events
+#if !UNITY_EDITOR
+#define UNITY_BUILD
+#endif
+
 using System;
 using System.Globalization;
 using System.Collections;
@@ -147,11 +152,6 @@ public static class NGIO {
 	private static bool _sessionReady = false;
 	private static bool _skipLogin = false;
 	private static bool _checkingConnectionStatus = false;
-
-	// External events
-	#if !UNITY_EDITOR
-	#define UNITY_BUILD
-	#endif
 
 	// tells the Newgrounds page a medal was unlocked so it can highlight in real time
 	// only used in WebGL builds


### PR DESCRIPTION
Hello! I tried to build an Unity WebGL project and got this error:

![image](https://user-images.githubusercontent.com/25650698/190934287-abeb669e-fd35-4a5f-a396-417f06cf1da2.png)

`Cannot define/undefine preprocessor symbols after first token in file`

I fixed it by moving the `#define` directive to the top of the `NGIO.cs` file.